### PR TITLE
DR-1172 Ensure proper validation of aws regions 

### DIFF
--- a/infrastructure/common/provider.tf
+++ b/infrastructure/common/provider.tf
@@ -9,7 +9,7 @@ provider "aws" {
   region = var.aws_region
 
   skip_metadata_api_check     = true
-  skip_region_validation      = true
+  skip_region_validation      = false
   skip_credentials_validation = true
 
   skip_requesting_account_id = false


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

The setting skip_region_validation has been set to false to ensure proper validation of AWS regions. This adjustment helps prevent configuration issues and ensures accurate resource deployment.

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
